### PR TITLE
fix(locale): remove HTML tag from Japanese translation

### DIFF
--- a/talos/src/locale/data/region/ja-JP.json
+++ b/talos/src/locale/data/region/ja-JP.json
@@ -127,7 +127,7 @@
           "residential_area": "居住区",
           "monitoring_center": "観測所",
           "marker_stone_flats": "界石広場",
-          "xiranflow_channel": "<p=\"そくりゅう\" padding=0>息流</p>道路",
+          "xiranflow_channel": "息流道路",
           "fangxing_avenue": "方興街",
           "tianshi_pillar_array": "天師杭陣",
           "maintenance_zone": "修繕工事区",


### PR DESCRIPTION
## Fix: Remove HTML tag from Japanese translation

### Motivation
Found an HTML `<p>` tag incorrectly included in a Japanese translation string.
Comparing with other language files confirms this is a typo.

### Changes
- `talos\src\locale\data\region\ja-JP.json`: Removed HTML tag from translation value
- Line 130: `<xiranflow_channel>` field

### Testing
- [x] Builds successfully
- [x] Type-check passes
- [x] Tested language switching to Japanese in dev server
- [x] Verified the corrected text displays properly