### PR TITLE
fix(user-guide): last step "Next" button does not complete tour 

### DIFF
--- a/talos/src/component/userGuide/tooltip/tooltip.tsx
+++ b/talos/src/component/userGuide/tooltip/tooltip.tsx
@@ -22,7 +22,6 @@ interface TooltipHeaderInterface {
     onClickBack?: MouseEventHandler<HTMLElement>;
     onClickNext?: MouseEventHandler<HTMLElement>;
     onClickSkip?: MouseEventHandler<HTMLElement>;
-    onComplete?: MouseEventHandler<HTMLElement>;
     index: number;
     size: number;
 }
@@ -70,11 +69,7 @@ const TooltipHeader = (prop: TooltipHeaderInterface) => {
                     text=''
                     buttonType='next'
                     buttonStyle='icon'
-                    onClick={
-                        prop.index !== prop.size - 1
-                            ? prop.onClickNext
-                            : prop.onComplete
-                    }
+                    onClick={prop.onClickNext}
                     size={'1.5rem'}
                     schema={buttonSchema}
                 />
@@ -88,7 +83,6 @@ export const GuideTooltip = ({
     index,
     step,
     backProps,
-    closeProps,
     primaryProps,
     skipProps,
     size,
@@ -100,7 +94,6 @@ export const GuideTooltip = ({
                     onClickBack={backProps.onClick}
                     onClickNext={primaryProps.onClick}
                     onClickSkip={skipProps.onClick}
-                    onComplete={closeProps.onClick}
                     index={index}
                     size={size}
                 />


### PR DESCRIPTION
### **Motivation**
In the `tooltip` component, the "NEXT" button on the **last step** was wired to `closeProps.onClick` instead of `primaryProps.onClick`. This causes the tour to not finish properly if the user clicks the "NEXT" button on the last step.

(Demo video)
https://github.com/user-attachments/assets/8920eeae-c779-4b31-9eba-860cf66d905e

### **Solution**
Always use `primaryProps.onClick` for the forward/"NEXT" button, regardless of step index

### **Testing performed**
- [x] The tooltip closes successfully at last step by pressing the "NEXT" button
- [x] All steps marked as completed in localStorage
- [x] No console errors during tour
- [x] `pnpm build` and `pnpm type-check` passed