### PR TITLE
fix: prevent sub-region boundaries from disappearing on region switch in boundary mode

### DIFF
--- a/talos/src/component/map/boundary.ts
+++ b/talos/src/component/map/boundary.ts
@@ -48,16 +48,17 @@ export class SubregionBoundaryManager {
     hideBoundaries() {
         if (!this.boundariesLayer) return;
         
+        const boundariesLayerToBeRemoved = this.boundariesLayer;
+        
         const layers: L.Layer[] = [];
         this.boundariesLayer.eachLayer(layer => layers.push(layer));
         
         this.toggleBoundaryVisibility(layers, true);
         
         setTimeout(() => {
-            if (this.boundariesLayer) {
-                this.map.removeLayer(this.boundariesLayer);
+            this.map.removeLayer(boundariesLayerToBeRemoved);
+            if (this.boundariesLayer === boundariesLayerToBeRemoved) 
                 this.boundariesLayer = undefined;
-            }
         }, 300); // equal to the CSS transition duration
     }
 

--- a/talos/src/component/mapCore/map.ts
+++ b/talos/src/component/mapCore/map.ts
@@ -78,9 +78,6 @@ export class MapCore {
     async switchRegion(regionId: string): Promise<void> {
         this.currentRegionId = regionId;
 
-        // 清理子地区边界层
-        this.boundaryManager.hideBoundaries();
-
         this.map.eachLayer((layer) => this.map.removeLayer(layer));
 
         const config = REGION_DICT[regionId];


### PR DESCRIPTION
**Motivation**  
Sub-region boundaries vanish after switching regions, even when boundary mode is enabled.

**Cause**  
Race condition in `hideBoundaries()`: it schedules removal of `this.boundariesLayer` after 300 ms, but by then `this.boundariesLayer` has been replaced with a new layer → the new (visible) layer gets cleared instead.

**Fix**  
Capture the layer to remove and only clear `this.boundariesLayer` if it still matches that reference.

**Testing**
- [x] Sub-region boundaries stay visible after switching regions (with boundaries enabled)
- [x] `pnpm build` passes
- [x] `pnpm type-check` passes 


