### PR TITLE
fix(marker): sync selected state with CSS classes on undo/redo

### DIFF
--- a/talos/src/component/mapCore/marker/markerLayer.ts
+++ b/talos/src/component/mapCore/marker/markerLayer.ts
@@ -62,8 +62,8 @@ export class MarkerLayer {
         // 初始化markerType到markerId列表的映射
         this.markerTypeMap = Object.values(MARKER_TYPE_DICT).reduce(
             (acc, type) => {
-                acc[type.key] = [];
-                return acc;
+            acc[type.key] = [];
+            return acc;
             },
             {},
         );
@@ -71,12 +71,12 @@ export class MarkerLayer {
         // 为每个subregion生成LayerGroup
         this.layerSubregionDict = Object.values(REGION_DICT).reduce(
             (acc, region) => {
-                region.subregions.forEach((subregion) => {
-                    acc[subregion] = new L.LayerGroup([], {
-                        pane: 'markerPane',
-                    });
+            region.subregions.forEach((subregion) => {
+                acc[subregion] = new L.LayerGroup([], {
+                    pane: 'markerPane',
                 });
-                return acc;
+            });
+            return acc;
             },
             {},
         );
@@ -184,6 +184,20 @@ export class MarkerLayer {
         });
     }
 
+    // update changed selected points' visual state 
+    updateSelectedMarkers(changedSelectedPoints: {id: string, selected: boolean}[]) {
+        changedSelectedPoints.forEach(({id, selected}) => {
+            const layer = this.markerDict[id];
+            if (!layer) return;
+            const markerRoot = (layer as L.Marker).getElement?.() as HTMLElement | null;
+            if (!markerRoot) return;
+            const inner = markerRoot.querySelector(`.${styles.markerInner}, .${styles.noFrameInner}`);
+            if (!inner) return;
+
+            inner.classList.toggle(styles.selected, selected);
+        });
+    }
+
     /**
      * 导入marker列表
      */
@@ -210,7 +224,7 @@ export class MarkerLayer {
         Object.values(this.layerSubregionDict).forEach((layer) => {
             layer.removeFrom(this.map);
         });
-        
+
         const subregions = REGION_DICT[regionId].subregions;
         subregions.forEach((subregion) => {
             this.layerSubregionDict[subregion].addTo(this.map);
@@ -298,13 +312,13 @@ export class MarkerLayer {
      */
     getVisibleMarkerCount(): number {
         const clusterEnabled = this.clusterLayer.isEnabled();
-        
+
         // 统计当前激活的filter对应的marker数量
         const visibleMarkerIds = (clusterEnabled
             ? this.activeFilterKeys.filter((key) => !this.clusterLayer.isTypeManaged(key))
             : this.activeFilterKeys
         ).flatMap((key) => this.markerTypeMap[key] || []);
-        
+
         return visibleMarkerIds.length;
     }
 


### PR DESCRIPTION
### Motivation
**undo/redo operations** on marker selection only update the Zustand store (`selectedPoints`), but **do not visually reflect** the change in the UI.  

Markers that were selected or deselected via history actions remain in their old visual state (wrong `.selected` class).

### Root Cause
History actions only mutate the store:
```ts
useHistoryStore.getState().push({
    label: `Select ${id}`,
    // only mutate state
    undo: () => useMarkerStore.getState().setSelected(id, false), 
    redo: () => useMarkerStore.getState().setSelected(id, true),
});
```

### Solution
Introduce a hook (in useMarker.ts) that watches selectedPoints changes.
- Compute added/removed IDs (using useRef for previous state).
- Call a new MarkerLayer method updateSelectedMarkers to toggle the .selected class only on affected markers.

This should decouple DOM manipulation from event handlers (click, lasso, etc.).

###Testing

- [x]  Tested single click select/deselect
- [x] Lasso multi-select + batch check
- [x] Undo/redo (Cmd+Z / Shift+Cmd+Z) now visually correct
- [x] Initial load with pre-selected markers
- [x] pnpm build passes
- [x] pnpm type-check passes


**Note:**  
Several places (click handlers, lasso, initial render, etc.) still manually toggle `.selected` classes.  
Once this reactive pattern is confirmed, I can open a follow-up PR to refactor those.

