### PR TITLE
fix: remove PopoverTooltip wrapper span that broke headbar nth-of-type selectors

### DIFF
--- a/talos/src/component/headBar/headbar.module.scss
+++ b/talos/src/component/headBar/headbar.module.scss
@@ -46,8 +46,7 @@
         pointer-events: none;
     }
 
-    /* per item action */
-    &:nth-of-type(4)>.headbarIcon {
+    &[data-guide='headbar-dark-mode']>.headbarIcon {
         transition: transform 0.45s $moderato-curve;
         transform: var(--darkmode-rotate);
     }
@@ -224,14 +223,9 @@
     }
 
 
-    .headbarItem {
-        &:nth-of-type(4)>.headbarIcon {
-            transform: rotate(0);
-        }
-        &:nth-of-type(5)>.headbarIcon {
-            transform: var(--darkmode-rotate);
-            transition: transform 0.45s $moderato-curve;
-        }
+    .headbarItem[data-guide='headbar-dark-mode']>.headbarIcon {
+        transform: var(--darkmode-rotate);
+        transition: transform 0.45s $moderato-curve;
     }
 }
 .headbarGrid {

--- a/talos/src/component/popover/popover.tsx
+++ b/talos/src/component/popover/popover.tsx
@@ -28,7 +28,7 @@ const PopoverTooltip: React.FC<PopoverTooltipProps> = ({
 }) => {
     const hoverTimeoutRef = useRef<number | undefined>(undefined);
     const controlledCloseTimeoutRef = useRef<number | undefined>(undefined);
-    const triggerRef = useRef<HTMLSpanElement | null>(null);
+    const triggerRef = useRef<HTMLElement | null>(null);
     const popoverIdRef = useRef<string>(`tooltip-${Math.random().toString(36).substr(2, 9)}`);
 
     // Cleanup function: ensure popover is closed
@@ -181,27 +181,24 @@ const PopoverTooltip: React.FC<PopoverTooltipProps> = ({
     const originalOnMouseLeave = childProps.onMouseLeave as ((e: React.MouseEvent<HTMLElement>) => void) | undefined;
 
     const childWithHandlers = React.cloneElement(children, {
+        ref: triggerRef,
         onMouseEnter: (e: React.MouseEvent<HTMLElement>) => {
             handleMouseEnter(e);
-            // Call original onMouseEnter if exists
             if (originalOnMouseEnter) {
                 originalOnMouseEnter(e);
             }
         },
         onMouseLeave: (e: React.MouseEvent<HTMLElement>) => {
             handleMouseLeave();
-            // Call original onMouseLeave if exists
             if (originalOnMouseLeave) {
                 originalOnMouseLeave(e);
             }
         },
-    } as Partial<React.HTMLAttributes<HTMLElement>>);
+    } as Partial<React.HTMLAttributes<HTMLElement>> & { ref: React.Ref<HTMLElement> });
 
     return (
         <>
-            <span className={styles.popoverAnchor} ref={triggerRef}>
-                {childWithHandlers}
-            </span>
+            {childWithHandlers}
             <div
                 id={popoverIdRef.current}
                 popover="manual"

--- a/talos/src/component/uiOverlay/UIOverlay.tsx
+++ b/talos/src/component/uiOverlay/UIOverlay.tsx
@@ -108,12 +108,18 @@ const UIOverlay: React.FC<UIOverlayProps> = ({ map, isSidebarOpen, visible = tru
     };
     const handleGroup = () => setGroupOpen(true);
 
+    const [isDark, setIsDark] = useState(false);
+
     useEffect(() => {
         initTheme();
+        setIsDark(document.documentElement.getAttribute('data-theme') === 'dark');
         return () => cleanupTheme();
     }, []);
 
-    const handleDarkMode = () => toggleTheme();
+    const handleDarkMode = () => {
+        toggleTheme();
+        setIsDark((prev) => !prev);
+    };
     const handleLanguage = () => setLangOpen(true);
     const handleHelp = () => setIsUserGuideOpen(true);
     const handleSettings = () => setSettingsOpen(true);
@@ -156,7 +162,7 @@ const UIOverlay: React.FC<UIOverlayProps> = ({ map, isSidebarOpen, visible = tru
                 <HeadItem
                     icon={Darkmode}
                     onClick={handleDarkMode}
-                    tooltip={t('headbar.darkmode')}
+                    tooltip={isDark ? t('headbar.lightmode') : t('headbar.darkmode')}
                     guideKey='headbar-dark-mode'
                 />
                 <HeadItem


### PR DESCRIPTION
PopoverTooltip wraps each child in a <span class="popoverAnchor">, isolating every headbar <button> into its own parent. This makes all nth-of-type(N) selectors on .headbarItem resolve to nth-of-type(1) within each span, so none of them match for N > 1.

<img width="1500" height="431" alt="image" src="https://github.com/user-attachments/assets/9b2f2b13-6ca7-4bae-8626-a1b88cd90fdb" />

Broken by this:
- Darkmode icon rotate3d transform (desktop nth-of-type(4), mobile nth-of-type(5))
- Mobile expand/collapse wave-stagger transition delays (nth-of-type 2–9)

Fix: pass triggerRef to the child via cloneElement instead of wrapping in a <span>.
The popover "div" remains as a sibling; it is display:none when hidden and renders in the top layer when shown, so it does not affect flex/grid layout or button-type nth-of-type counting.

Also fixes the darkmode tooltip staying static across theme switches — it now reads the current theme to pick between headbar.darkmode / headbar.lightmode locale keys.
The darkmode-specific CSS selector is changed from nth-of-type to a data-guide attribute selector for additional robustness.