### PR TITLE
fix(css): idcard content transform on Firefox

### DIFF
--- a/talos/src/component/login/idcard.module.scss
+++ b/talos/src/component/login/idcard.module.scss
@@ -33,7 +33,6 @@ $karma-5: url('@/assets/images/UI/avt/Karma5.png');
     height: 8.5rem;
     width: 21rem;
     max-width: 95%;
-    padding: 1.5rem 1rem 1.5rem 1.5rem;
     box-sizing: border-box;
     background-color: #333;
     border-radius: 6% 6% 6% 6% / 12% 12% 12% 12%;
@@ -96,6 +95,7 @@ $karma-5: url('@/assets/images/UI/avt/Karma5.png');
 
 .idCardWrap {
     position: relative;
+    padding: 1.5rem 1rem 1.5rem 1.5rem;
     display: grid;
     justify-content: start;
     grid-template-columns: 0.5fr repeat(3, 0.4fr);

--- a/talos/src/component/login/idcard.module.scss
+++ b/talos/src/component/login/idcard.module.scss
@@ -95,7 +95,7 @@ $karma-5: url('@/assets/images/UI/avt/Karma5.png');
 
 .idCardWrap {
     position: relative;
-    padding: 1.5rem 1rem 1.5rem 1.5rem;
+    padding: 1.25rem 1rem 1.25rem 1.5rem;
     display: grid;
     justify-content: start;
     grid-template-columns: 0.5fr repeat(3, 0.4fr);

--- a/talos/src/component/login/idcard.module.scss
+++ b/talos/src/component/login/idcard.module.scss
@@ -99,7 +99,7 @@ $karma-5: url('@/assets/images/UI/avt/Karma5.png');
     display: grid;
     justify-content: start;
     grid-template-columns: 0.5fr repeat(3, 0.4fr);
-    grid-template-rows: repeat(4, 0.4fr);
+    grid-template-rows: repeat(4, auto);
     grid-auto-columns: 1fr;
     grid-auto-rows: 1fr;
     gap: 0;

--- a/talos/src/component/login/idcard.module.scss
+++ b/talos/src/component/login/idcard.module.scss
@@ -95,11 +95,11 @@ $karma-5: url('@/assets/images/UI/avt/Karma5.png');
 }
 
 .idCardWrap {
-    margin: -0.25rem;
+    position: relative;
     display: grid;
     justify-content: start;
     grid-template-columns: 0.5fr repeat(3, 0.4fr);
-    grid-template-rows: repeat(4, 0.5fr);
+    grid-template-rows: repeat(4, 0.4fr);
     grid-auto-columns: 1fr;
     grid-auto-rows: 1fr;
     gap: 0;
@@ -112,8 +112,10 @@ $karma-5: url('@/assets/images/UI/avt/Karma5.png');
 
     > .avatarContainer {
         grid-area: avatar;
-        width: 6rem;
-        height: 6rem;
+        position: relative;
+        width: 5.5rem;
+        height: 5.5rem;
+        top: 0.5rem;
         padding: 0;
         margin: 0;
         border: none;
@@ -133,9 +135,11 @@ $karma-5: url('@/assets/images/UI/avt/Karma5.png');
         }
 
         > .avatar {
-            width: calc(6rem + 28px);
-            height: calc(6rem + 26px);
-            transform: translate(-20px, -30px);
+            position: relative;
+            width: calc(5.5rem + 28px);
+            height: calc(5.5rem + 26px);
+            left: calc(0.5rem - 28px);
+            top: calc(-3.5rem + 26px);
             object-fit: cover;
             background-image: $avatar-default;
             background-position: center top;
@@ -279,7 +283,8 @@ $karma-5: url('@/assets/images/UI/avt/Karma5.png');
         position: absolute;
         width: 100%;
         height: 100%;
-        transform: translate(-1.2rem, -20px);
+        left: 0;
+        top: 0;
         background-image: $cardbak;
         background-size: contain;
         image-rendering: pixelated;

--- a/talos/src/component/login/idcard.module.scss
+++ b/talos/src/component/login/idcard.module.scss
@@ -95,11 +95,11 @@ $karma-5: url('@/assets/images/UI/avt/Karma5.png');
 }
 
 .idCardWrap {
+    margin: -0.25rem;
     display: grid;
-    align-items: end;
     justify-content: start;
     grid-template-columns: 0.5fr repeat(3, 0.4fr);
-    grid-template-rows: repeat(4, 0.25fr);
+    grid-template-rows: repeat(4, 0.5fr);
     grid-auto-columns: 1fr;
     grid-auto-rows: 1fr;
     gap: 0;
@@ -112,8 +112,8 @@ $karma-5: url('@/assets/images/UI/avt/Karma5.png');
 
     > .avatarContainer {
         grid-area: avatar;
-        width: 5.5rem;
-        height: 5.5rem;
+        width: 6rem;
+        height: 6rem;
         padding: 0;
         margin: 0;
         border: none;
@@ -133,8 +133,8 @@ $karma-5: url('@/assets/images/UI/avt/Karma5.png');
         }
 
         > .avatar {
-            width: calc(5.5rem + 28px);
-            height: calc(5.5rem + 26px);
+            width: calc(6rem + 28px);
+            height: calc(6rem + 26px);
             transform: translate(-20px, -30px);
             object-fit: cover;
             background-image: $avatar-default;
@@ -279,7 +279,7 @@ $karma-5: url('@/assets/images/UI/avt/Karma5.png');
         position: absolute;
         width: 100%;
         height: 100%;
-        transform: translate(-1.5rem, 22px);
+        transform: translate(-1.2rem, -20px);
         background-image: $cardbak;
         background-size: contain;
         image-rendering: pixelated;


### PR DESCRIPTION
L: Chrome  
R: Firefox

<img width="1919" height="991" alt="图片" src="https://github.com/user-attachments/assets/05e7a60c-fbbd-42d6-bede-afea6d2517f5" />

Not tested on Safari yet.

```diff
 .idCardWrap {
-    align-items: end;
     justify-content: start;
-    grid-template-rows: repeat(4, 0.25fr);
+    grid-template-rows: repeat(4, 0.5fr);
     grid-auto-columns: 1fr;
     grid-auto-rows: 1fr;
     gap: 0;
```