### PR TITLE
feat: 新增 Shift+点击反向循环头像

### DIFF
--- a/talos/src/component/login/avatarConfig.ts
+++ b/talos/src/component/login/avatarConfig.ts
@@ -29,3 +29,6 @@ export const normalizeAvatarIndex = (value: unknown): number => {
 
 export const getNextAvatarIndex = (current: number): number =>
   current >= AVATAR_MAX_INDEX ? 1 : current + 1;
+
+export const getPrevAvatarIndex = (current: number): number =>
+  current <= 1 ? AVATAR_MAX_INDEX : current - 1;

--- a/talos/src/component/login/idcardView.tsx
+++ b/talos/src/component/login/idcardView.tsx
@@ -22,7 +22,7 @@ interface IdCardViewProps {
   cardRef?: RefObject<HTMLDivElement | null>;
   onCardMouseMove?: MouseEventHandler<HTMLDivElement>;
   onCardMouseLeave?: MouseEventHandler<HTMLDivElement>;
-  onAvatarClick?: () => void;
+  onAvatarClick?: MouseEventHandler<HTMLButtonElement>;
   avatarAriaLabel?: string;
   avatarIndex?: number;
   editableName?: boolean;

--- a/talos/src/component/login/profile/profile.tsx
+++ b/talos/src/component/login/profile/profile.tsx
@@ -16,7 +16,8 @@ interface ProfileModalProps {
   isSavingProfile: boolean;
   cardProfile: IdCardRenderModel;
   profileAvatar: number;
-  onAvatarCycle: () => void;
+  /** `1` = next avatar, `-1` = previous avatar */
+  onAvatarCycle: (direction: 1 | -1) => void;
   handleCloseProfile: () => Promise<void>;
   handleSaveProfile: () => Promise<void>;
   handleLogout: () => Promise<void>;
@@ -69,7 +70,8 @@ const ProfileModal = ({
           cardRef={cardRef}
           onCardMouseMove={handleCardMouseMove}
           onCardMouseLeave={handleCardMouseLeave}
-          onAvatarClick={onAvatarCycle}
+          {/* Shift+click cycles backward through the avatar table */}
+          onAvatarClick={(e) => onAvatarCycle(e.shiftKey ? -1 : 1)}
           avatarAriaLabel={t('idcard.profile.avatarHint')}
           avatarIndex={profileAvatar}
           editableName

--- a/talos/src/component/login/profile/profile.tsx
+++ b/talos/src/component/login/profile/profile.tsx
@@ -70,7 +70,6 @@ const ProfileModal = ({
           cardRef={cardRef}
           onCardMouseMove={handleCardMouseMove}
           onCardMouseLeave={handleCardMouseLeave}
-          {/* Shift+click cycles backward through the avatar table */}
           onAvatarClick={(e) => onAvatarCycle(e.shiftKey ? -1 : 1)}
           avatarAriaLabel={t('idcard.profile.avatarHint')}
           avatarIndex={profileAvatar}

--- a/talos/src/component/login/useIdCardAuthController.ts
+++ b/talos/src/component/login/useIdCardAuthController.ts
@@ -15,7 +15,7 @@ import {
   updateProfileNickname,
 } from './authFlow';
 import { getVerificationDigits, resolveErrorCode, type AuthMode, type AuthValues } from './access/authState';
-import { getNextAvatarIndex, normalizeAvatarIndex } from './avatarConfig';
+import { getNextAvatarIndex, getPrevAvatarIndex, normalizeAvatarIndex } from './avatarConfig';
 import { useAuthStore } from '@/store/auth';
 import { getCachedSession } from '@/utils/backendCache';
 
@@ -207,8 +207,10 @@ export const useIdCardAuthController = () => {
     openAuthModal(hasLoggedInBefore ? 'login' : 'register');
   }, [authReady, hasLoggedInBefore, openAuthModal, openProfileModal, sessionUser]);
 
-  const handleCycleProfileAvatar = useCallback(() => {
-    setProfileAvatar((current) => getNextAvatarIndex(current));
+  const handleCycleProfileAvatar = useCallback((direction: 1 | -1) => {
+    setProfileAvatar((current) =>
+      direction === 1 ? getNextAvatarIndex(current) : getPrevAvatarIndex(current),
+    );
   }, []);
 
   const handleDiscordAuthClick = useCallback(async () => {


### PR DESCRIPTION
## Summary

- 新增 **Shift+点击反向循环头像** 功能（在个人资料弹窗中），补全原有仅正向点击的行为
- 普通点击继续切换到下一个头像；Shift+点击切换到上一个头像

## Changes

| File | Change |
|------|--------|
| `avatarConfig.ts` | 添加 `getPrevAvatarIndex` —— 镜像 `getNextAvatarIndex`，从 1 回绕至 `AVATAR_MAX_INDEX` |
| `idcardView.tsx` | 将 `onAvatarClick` 属性类型从 `() => void` 拓宽为 `MouseEventHandler<HTMLButtonElement>`，以便调用方检查修饰键 |
| `profile/profile.tsx` | 在点击处理中检测 `event.shiftKey`，将方向 `1`（正向）/ `-1`（反向）传递给 `onAvatarCycle` |
| `useIdCardAuthController.ts` | `handleCycleProfileAvatar` 现在接受 `(direction: 1 \| -1)`，并根据方向调用 `getNextAvatarIndex` 或 `getPrevAvatarIndex` |

## Architecture note

遵循现有的分层：DOM 事件细节（`shiftKey`）在视图层（`profile.tsx`）处理，控制器（`useIdCardAuthController`）接收纯数据值（`1 \| -1`）。侧边栏头像点击行为不受影响——`handleAvatarClick` 忽略多余的事件参数，始终打开个人资料弹窗。

## Test plan

- [x] 个人资料弹窗：点击头像 → 切换到下一个头像
- [ ] 个人资料弹窗：Shift+点击头像 → 返回到上一个头像
- [ ] 个人资料弹窗：在头像 1 处 Shift+点击 → 回绕到头像 35
- [ ] 个人资料弹窗：在头像 35 处点击 → 回绕到头像 1
- [ ] 侧边栏：点击头像（无论是否按下 Shift）→ 打开个人资料弹窗（无变化）