### PR TITLE
fix(notification): refresh all categories after reconnect

### DIFF
--- a/talos/src/component/notify/notify.tsx
+++ b/talos/src/component/notify/notify.tsx
@@ -25,6 +25,7 @@ import {
     listNotifications,
     markAllNotificationsRead,
     markNotificationsRead,
+    NOTIFICATION_CATEGORIES,
     notificationCategoryForType,
     type NotificationCategory,
     type NotificationItem,
@@ -579,7 +580,9 @@ const NotifyModal: React.FC<NotifyProps> = ({
             publishUnread(EMPTY_UNREAD);
             return;
         }
-        void Promise.all([loadCategory('community'), loadCategory('system')]);
+        void Promise.all(
+            NOTIFICATION_CATEGORIES.map((category) => loadCategory(category)),
+        );
         // Initial loads do not consume a cursor from the captured feed state.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [open, sessionUid]);
@@ -612,8 +615,10 @@ const NotifyModal: React.FC<NotifyProps> = ({
         }
         if (syncVersion <= handledSyncVersionRef.current) return;
         handledSyncVersionRef.current = syncVersion;
-        void loadCategory(activeCategory);
-    }, [activeCategory, loadCategory, open, syncVersion]);
+        void Promise.all(
+            NOTIFICATION_CATEGORIES.map((category) => loadCategory(category)),
+        );
+    }, [loadCategory, open, syncVersion]);
 
     const handleRead = useCallback(
         (item: NotificationItem) => {

--- a/talos/src/utils/notifyClient.ts
+++ b/talos/src/utils/notifyClient.ts
@@ -1,6 +1,8 @@
 import { getAuthBase, getAuthHeaders } from '@/component/login/authFlow';
 
-export type NotificationCategory = 'system' | 'community';
+export const NOTIFICATION_CATEGORIES = ['community', 'system'] as const;
+
+export type NotificationCategory = (typeof NOTIFICATION_CATEGORIES)[number];
 
 export type NotificationType =
     | 'system.submission.approved'


### PR DESCRIPTION
## Summary

- Refresh every notification category when the notification WebSocket reconnects.
- Define notification categories in one readonly runtime list and derive the `NotificationCategory` TypeScript union from it.

## Problem

Previously, reconnecting refreshed only the currently active notification category.

### Before

User opens the notification panel
→ selects Moderations
→ WebSocket disconnects
→ someone upvotes the user’s comment
→ a new Interactions notification is created
→ WebSocket reconnects
→ unread count increases
→ app refreshes only Moderations
→ user opens Interactions
→ unread indicator is visible, but the new notification is missing
→ user closes and reopens the panel
→ Interactions refreshes
→ new notification finally appears

### After

WebSocket reconnects
→ app refreshes all notification categories
→ unread counts and notification feeds stay synchronized
→ user opens Interactions
→ new notification appears immediately

## Testing

- `pnpm test` — 3 tests passed
- Targeted ESLint — passed
- `pnpm run type-check` — passed