### PR TITLE
feat(ugc): support image deep links

### DIFF
--- a/talos/src/component/detail/detail.tsx
+++ b/talos/src/component/detail/detail.tsx
@@ -526,6 +526,7 @@ export const Detail = ({ inline = false, className }: DetailProps) => {
                                 buttonType='close'
                                 onClick={(e) => {
                                     e.stopPropagation();
+                                    useMarkerStore.getState().clearImageOpenRequest();
                                     setDetailPhase('exiting');
                                 }}
                             />

--- a/talos/src/component/notify/notify.tsx
+++ b/talos/src/component/notify/notify.tsx
@@ -668,10 +668,16 @@ const NotifyModal: React.FC<NotifyProps> = ({
         (item: NotificationItem, readItem = item) => {
             const markerId = item.target.markerId;
             if (!markerId) return;
+            const imageTarget = item.target.submissionId?.trim();
+            const imageId = item.payload.kind === 'image' && imageTarget
+                ? imageTarget
+                : undefined;
             handleRead(readItem);
             onClose();
             onChange?.(false);
-            void navigateToMarkerId(markerId);
+            void navigateToMarkerId(markerId, {
+                content: imageId ? { kind: 'image', id: imageId } : undefined,
+            });
         },
         [handleRead, onChange, onClose],
     );

--- a/talos/src/component/uploader/uploader.tsx
+++ b/talos/src/component/uploader/uploader.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo, type CSSProperties } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, type CSSProperties } from 'react';
 import classNames from 'classnames';
 import styles from './uploader.module.scss';
 import Viewer from '../detail/viewer/viewer';
@@ -13,7 +13,7 @@ import ShortActions, { type ShortActionItem } from './shortActions';
 import LikeIcon from '@/assets/images/UI/like.svg?react';
 import FlagIcon from '@/assets/images/UI/flag.svg?react';
 import RecallIcon from '@/assets/images/UI/recall.svg?react';
-import useUGCPointImages from './useUGCPointImages';
+import useUGCPointImages, { isPublic } from './useUGCPointImages';
 import useUGCUpload from './useUGCUpload';
 import useUGCImageActions from './useUGCImageActions';
 import useImageUiState from './useImageUiState';
@@ -40,7 +40,7 @@ const Uploader = memo(({ point, pointName, active: activeDetail = true }: Props)
     const interaction = useUploadInteraction(point, uploadState, activeDetail, actionsState.viewerOpen);
     const carousel = useCarousel();
 
-    const { active, activeImages, selectedImageId, setSelectedImageId, show, loading } = imageState;
+    const { active, activeImages, selectedImageId, setSelectedImageId, show, loading, shouldOpenViewer, acknowledgeViewerOpen } = imageState;
     const {
         uploading,
         uploadSent,
@@ -78,7 +78,15 @@ const Uploader = memo(({ point, pointName, active: activeDetail = true }: Props)
         handleCarouselLayerKeyDown,
     } = carousel;
 
-    const { copiedPopupVisible, copyPointShareUrl } = usePointShareLink(point);
+    const { copiedPopupVisible, copyPointShareUrl } = usePointShareLink(point, {
+        content: active && isPublic(active) ? { kind: 'image', id: active.id } : undefined,
+    });
+
+    useEffect(() => {
+        if (!shouldOpenViewer || !active || active.id !== selectedImageId) return;
+        setViewerOpen(true);
+        acknowledgeViewerOpen();
+    }, [acknowledgeViewerOpen, active, selectedImageId, setViewerOpen, shouldOpenViewer]);
 
     const progressStyle = useMemo(
         () => ({ '--uploader-progress': `${Math.round(progress * 100)}%` }) as CSSProperties,

--- a/talos/src/component/uploader/uploader.tsx
+++ b/talos/src/component/uploader/uploader.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useEffect, useMemo, type CSSProperties } from 'react';
+import React, { memo, useCallback, useMemo, type CSSProperties } from 'react';
 import classNames from 'classnames';
 import styles from './uploader.module.scss';
 import Viewer from '../detail/viewer/viewer';
@@ -37,10 +37,10 @@ const Uploader = memo(({ point, pointName, active: activeDetail = true }: Props)
     const uploadState = useUGCUpload(point, imageState);
     const actionsState = useUGCImageActions(imageState, uploadState);
     const uiState = useImageUiState(imageState, uploadState);
-    const interaction = useUploadInteraction(point, uploadState, activeDetail, actionsState.viewerOpen);
+    const interaction = useUploadInteraction(point, uploadState, activeDetail, imageState.viewerOpen);
     const carousel = useCarousel();
 
-    const { active, activeImages, selectedImageId, setSelectedImageId, show, loading, shouldOpenViewer, acknowledgeViewerOpen } = imageState;
+    const { active, activeImages, selectedImageId, setSelectedImageId, show, loading, viewerOpen, setViewerOpen } = imageState;
     const {
         uploading,
         uploadSent,
@@ -57,8 +57,6 @@ const Uploader = memo(({ point, pointName, active: activeDetail = true }: Props)
         actionPending,
         recallConfirming,
         cancelRecallConfirmation,
-        viewerOpen,
-        setViewerOpen,
         handleToggleUpvote,
         handleToggleFlag,
         handleToggleRecall,
@@ -81,12 +79,6 @@ const Uploader = memo(({ point, pointName, active: activeDetail = true }: Props)
     const { copiedPopupVisible, copyPointShareUrl } = usePointShareLink(point, {
         content: active && isPublic(active) ? { kind: 'image', id: active.id } : undefined,
     });
-
-    useEffect(() => {
-        if (!shouldOpenViewer || !active || active.id !== selectedImageId) return;
-        setViewerOpen(true);
-        acknowledgeViewerOpen();
-    }, [acknowledgeViewerOpen, active, selectedImageId, setViewerOpen, shouldOpenViewer]);
 
     const progressStyle = useMemo(
         () => ({ '--uploader-progress': `${Math.round(progress * 100)}%` }) as CSSProperties,

--- a/talos/src/component/uploader/useUGCImageActions.ts
+++ b/talos/src/component/uploader/useUGCImageActions.ts
@@ -1,13 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuthStore } from '@/store/auth';
 import { openOemAuthModal } from '@/component/login/authEvents';
 import {
     recallUGCImage,
     toggleUGCImageFlag,
     toggleUGCImageUpvote,
-    type UGCImage,
     type UGCImageActionPatch,
-    type UGCSubmissionImage,
 } from '@/utils/ugcClient';
 import { getUpvoteCount, type PointImagesState } from './useUGCPointImages';
 import type { UploadState } from './useUGCUpload';
@@ -43,8 +41,6 @@ export type ImageActionsState = {
     actionPending: boolean;
     recallConfirming: boolean;
     cancelRecallConfirmation: () => void;
-    viewerOpen: boolean;
-    setViewerOpen: React.Dispatch<React.SetStateAction<boolean>>;
     handleToggleUpvote: () => void;
     handleToggleFlag: () => void;
     handleToggleRecall: () => Promise<void>;
@@ -58,7 +54,6 @@ const useUGCImageActions = (imageState: PointImagesState, uploadState: UploadSta
         imageId: string;
         armedAt: number;
     } | null>(null);
-    const [viewerOpen, setViewerOpen] = useState(false);
     const cancelRecallConfirmation = useCallback(() => setRecallConfirmation(null), []);
     const upvoteTasksRef = useRef(new Map<string, ToggleTask>());
     const flagTasksRef = useRef(new Map<string, ToggleTask>());
@@ -67,20 +62,20 @@ const useUGCImageActions = (imageState: PointImagesState, uploadState: UploadSta
         active,
         isOwnActive,
         applyServerImage,
+        patchImageById,
         setImages,
         setMyImages,
+        requestedImage,
+        setRequestedImage,
         images,
         myImages,
         selectedImageId,
         setSelectedImageId,
+        viewerOpen,
+        setViewerOpen,
     } = imageState;
 
     const { lastSubmission, setLastSubmission } = uploadState;
-
-    const patchImageById = useCallback((imageId: string, patch: (image: UGCImage) => UGCImage) => {
-        setImages((current) => current.map((image) => (image.id === imageId ? patch(image) : image)));
-        setMyImages((current) => current.map((image) => (image.id === imageId ? patch(image) as UGCSubmissionImage : image)));
-    }, [setImages, setMyImages]);
 
     const scheduleUpvoteSync = useCallback((imageId: string) => {
         const task = upvoteTasksRef.current.get(imageId);
@@ -246,11 +241,13 @@ const useUGCImageActions = (imageState: PointImagesState, uploadState: UploadSta
         const previousSubmission = lastSubmission;
         const previousImages = images;
         const previousMyImages = myImages;
+        const previousRequestedImage = requestedImage;
         const previousSelectedImageId = selectedImageId;
         const previousViewerOpen = viewerOpen;
         setLastSubmission(null);
         setImages((current) => current.filter((image) => image.id !== active.id));
         setMyImages((current) => current.filter((image) => image.id !== active.id));
+        setRequestedImage((current) => (current?.id === active.id ? null : current));
         setSelectedImageId(null);
         setViewerOpen(false);
         setActionPending(true);
@@ -260,19 +257,18 @@ const useUGCImageActions = (imageState: PointImagesState, uploadState: UploadSta
             setLastSubmission(previousSubmission);
             setImages(previousImages);
             setMyImages(previousMyImages);
+            setRequestedImage(previousRequestedImage);
             setSelectedImageId(previousSelectedImageId);
             setViewerOpen(previousViewerOpen);
         } finally {
             setActionPending(false);
         }
-    }, [actionPending, active, images, isAuthenticated, isOwnActive, lastSubmission, myImages, recallConfirmation, selectedImageId, setImages, setLastSubmission, setMyImages, setSelectedImageId, viewerOpen]);
+    }, [actionPending, active, images, isAuthenticated, isOwnActive, lastSubmission, myImages, recallConfirmation, requestedImage, selectedImageId, setImages, setLastSubmission, setMyImages, setRequestedImage, setSelectedImageId, setViewerOpen, viewerOpen]);
 
     return {
         actionPending,
         recallConfirming: Boolean(active && recallConfirmation?.imageId === active.id),
         cancelRecallConfirmation,
-        viewerOpen,
-        setViewerOpen,
         handleToggleUpvote,
         handleToggleFlag,
         handleToggleRecall,

--- a/talos/src/component/uploader/useUGCPointImages.ts
+++ b/talos/src/component/uploader/useUGCPointImages.ts
@@ -54,10 +54,12 @@ export type PointImagesState = {
     loading: boolean;
     show: boolean;
     target: ReturnType<typeof resolveUGCUploadTarget>;
-    patchActiveImage: (patch: (image: UGCImage) => UGCImage) => void;
+    requestedImage: UGCImage | null;
+    setRequestedImage: React.Dispatch<React.SetStateAction<UGCImage | null>>;
+    patchImageById: (imageId: string, patch: (image: UGCImage) => UGCImage) => void;
     applyServerImage: (serverImage: UGCImageActionPatch) => void;
-    shouldOpenViewer: boolean;
-    acknowledgeViewerOpen: () => void;
+    viewerOpen: boolean;
+    setViewerOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const useUGCPointImages = (point: IMarkerData): PointImagesState => {
@@ -69,7 +71,7 @@ const useUGCPointImages = (point: IMarkerData): PointImagesState => {
     const [publicImagesLoading, setPublicImagesLoading] = useState(true);
     const [myImagesLoading, setMyImagesLoading] = useState(Boolean(user));
     const [selectedImageId, setSelectedImageId] = useState<string | null>(null);
-    const [shouldOpenViewer, setShouldOpenViewer] = useState(false);
+    const [viewerOpen, setViewerOpen] = useState(false);
     const imageOpenRequest = useMarkerStore((state) => state.imageOpenRequest);
     const clearImageOpenRequest = useMarkerStore((state) => state.clearImageOpenRequest);
 
@@ -77,14 +79,12 @@ const useUGCPointImages = (point: IMarkerData): PointImagesState => {
         setImages([]);
         setRequestedImage(null);
         setSelectedImageId(null);
-        setShouldOpenViewer(false);
+        setViewerOpen(false);
         if (!target) {
             setPublicImagesLoading(false);
             return;
         }
 
-        // This flag belongs to this effect run. It ignores late results from an
-        // old marker load; it does not abort the underlying HTTP request.
         let disposed = false;
         setPublicImagesLoading(true);
         void listUGCImages(point.id)
@@ -144,7 +144,6 @@ const useUGCPointImages = (point: IMarkerData): PointImagesState => {
         [myImages, point.id],
     );
 
-    // Merge public and own records by ID so the UI has one display list.
     const activeImages = useMemo(() => {
         const merged = new Map<string, UGCImage>();
         pointImages.forEach((image) => {
@@ -209,14 +208,14 @@ const useUGCPointImages = (point: IMarkerData): PointImagesState => {
         }
         const { imageId } = imageOpenRequest;
         setRequestedImage(null);
-        setShouldOpenViewer(false);
+        setViewerOpen(false);
         let cancelled = false;
         void getUGCImageById(point.id, imageId)
             .then((image) => {
                 if (cancelled) return;
                 setRequestedImage(image);
                 setSelectedImageId(image.id);
-                setShouldOpenViewer(true);
+                setViewerOpen(true);
                 clearImageOpenRequest();
             })
             .catch(() => {
@@ -229,17 +228,11 @@ const useUGCPointImages = (point: IMarkerData): PointImagesState => {
         };
     }, [clearImageOpenRequest, imageOpenRequest, point.id]);
 
-    const acknowledgeViewerOpen = useCallback(() => {
-        // This only acknowledges the one-time signal; it does not close the viewer.
-        setShouldOpenViewer(false);
+    const patchImageById = useCallback((imageId: string, patch: (image: UGCImage) => UGCImage) => {
+        setImages((current) => current.map((image) => (image.id === imageId ? patch(image) : image)));
+        setMyImages((current) => current.map((image) => (image.id === imageId ? patch(image) as UGCSubmissionImage : image)));
+        setRequestedImage((current) => (current?.id === imageId ? patch(current) : current));
     }, []);
-
-    const patchActiveImage = useCallback((patch: (image: UGCImage) => UGCImage) => {
-        if (!active) return;
-        setImages((current) => current.map((image) => (image.id === active.id ? patch(image) : image)));
-        setMyImages((current) => current.map((image) => (image.id === active.id ? patch(image) as UGCSubmissionImage : image)));
-        setRequestedImage((current) => (current?.id === active.id ? patch(current) : current));
-    }, [active]);
 
     const applyServerImage = useCallback((serverImage: UGCImageActionPatch) => {
         setImages((current) => current.map((image) => (image.id === serverImage.id ? {
@@ -273,10 +266,12 @@ const useUGCPointImages = (point: IMarkerData): PointImagesState => {
         loading,
         show: Boolean(target) || pointImages.length > 0,
         target,
-        patchActiveImage,
+        requestedImage,
+        setRequestedImage,
+        patchImageById,
         applyServerImage,
-        shouldOpenViewer,
-        acknowledgeViewerOpen,
+        viewerOpen,
+        setViewerOpen,
     };
 };
 

--- a/talos/src/component/uploader/useUGCPointImages.ts
+++ b/talos/src/component/uploader/useUGCPointImages.ts
@@ -193,7 +193,10 @@ const useUGCPointImages = (point: IMarkerData): PointImagesState => {
         setSelectedImageId(activeImages[0].id);
     }, [activeImages, selectedImageId]);
 
-    const isOwnActive = Boolean(active && pointMyImages.some((image) => image.id === active.id));
+    const isOwnActive = Boolean(active && user && (
+        pointMyImages.some((image) => image.id === active.id)
+        || active.author?.publicUid === user.uid
+    ));
     const isActivePending = Boolean(active && isPending(active));
     const pendingOwn = useMemo(
         () => pointMyImages.find(isPending) ?? null,

--- a/talos/src/component/uploader/useUGCPointImages.ts
+++ b/talos/src/component/uploader/useUGCPointImages.ts
@@ -1,8 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAuthStore } from '@/store/auth';
+import { useMarkerStore } from '@/store/marker';
 import type { IMarkerData } from '@/data/marker';
 import { parseTimestamp } from '@/utils/timeFormat';
 import {
+    getUGCImageById,
     listUGCImages,
     listUGCMyImages,
     resolveUGCUploadTarget,
@@ -54,6 +56,8 @@ export type PointImagesState = {
     target: ReturnType<typeof resolveUGCUploadTarget>;
     patchActiveImage: (patch: (image: UGCImage) => UGCImage) => void;
     applyServerImage: (serverImage: UGCImageActionPatch) => void;
+    shouldOpenViewer: boolean;
+    acknowledgeViewerOpen: () => void;
 };
 
 const useUGCPointImages = (point: IMarkerData): PointImagesState => {
@@ -61,21 +65,28 @@ const useUGCPointImages = (point: IMarkerData): PointImagesState => {
     const target = useMemo(() => resolveUGCUploadTarget(point), [point]);
     const [images, setImages] = useState<UGCImage[]>([]);
     const [myImages, setMyImages] = useState<UGCSubmissionImage[]>([]);
-    const [publicImagesLoading, setPublicImagesLoading] = useState(false);
-    const [myImagesLoading, setMyImagesLoading] = useState(false);
+    const [requestedImage, setRequestedImage] = useState<UGCImage | null>(null);
+    const [publicImagesLoading, setPublicImagesLoading] = useState(true);
+    const [myImagesLoading, setMyImagesLoading] = useState(Boolean(user));
     const [selectedImageId, setSelectedImageId] = useState<string | null>(null);
+    const [shouldOpenViewer, setShouldOpenViewer] = useState(false);
+    const imageOpenRequest = useMarkerStore((state) => state.imageOpenRequest);
+    const clearImageOpenRequest = useMarkerStore((state) => state.clearImageOpenRequest);
 
     useEffect(() => {
         setImages([]);
-        setMyImages([]);
+        setRequestedImage(null);
         setSelectedImageId(null);
-        setPublicImagesLoading(false);
-        setMyImagesLoading(false);
-        if (!target) return;
+        setShouldOpenViewer(false);
+        if (!target) {
+            setPublicImagesLoading(false);
+            return;
+        }
 
+        // This flag belongs to this effect run. It ignores late results from an
+        // old marker load; it does not abort the underlying HTTP request.
         let disposed = false;
         setPublicImagesLoading(true);
-        setMyImagesLoading(Boolean(user));
         void listUGCImages(point.id)
             .then((nextImages) => {
                 if (!disposed) setImages(nextImages);
@@ -87,33 +98,53 @@ const useUGCPointImages = (point: IMarkerData): PointImagesState => {
                 if (!disposed) setPublicImagesLoading(false);
             });
 
-        if (user) {
-            void listUGCMyImages(point.id)
-                .then((nextImages) => {
-                    if (!disposed) setMyImages(nextImages);
-                })
-                .catch(() => {
-                    if (!disposed) setMyImages([]);
-                })
-                .finally(() => {
-                    if (!disposed) setMyImagesLoading(false);
-                });
+        return () => {
+            disposed = true;
+        };
+    }, [point.id, target]);
+
+    useEffect(() => {
+        setMyImages([]);
+        if (!target || !user) {
+            setMyImagesLoading(false);
+            return;
         }
+
+        let disposed = false;
+        setMyImagesLoading(true);
+        void listUGCMyImages(point.id)
+            .then((nextImages) => {
+                if (!disposed) setMyImages(nextImages);
+            })
+            .catch(() => {
+                if (!disposed) setMyImages([]);
+            })
+            .finally(() => {
+                if (!disposed) setMyImagesLoading(false);
+            });
 
         return () => {
             disposed = true;
         };
     }, [point.id, target, user]);
 
-    const pointImages = useMemo(
-        () => images.filter((image) => image.markerId === point.id),
-        [images, point.id],
-    );
+    const pointImages = useMemo(() => {
+        const merged = new Map(
+            images
+                .filter((image) => image.markerId === point.id)
+                .map((image) => [image.id, image] as const),
+        );
+        if (requestedImage?.markerId === point.id) {
+            merged.set(requestedImage.id, requestedImage);
+        }
+        return [...merged.values()];
+    }, [images, point.id, requestedImage]);
     const pointMyImages = useMemo(
         () => myImages.filter((image) => image.markerId === point.id),
         [myImages, point.id],
     );
 
+    // Merge public and own records by ID so the UI has one display list.
     const activeImages = useMemo(() => {
         const merged = new Map<string, UGCImage>();
         pointImages.forEach((image) => {
@@ -172,10 +203,42 @@ const useUGCPointImages = (point: IMarkerData): PointImagesState => {
 
     const loading = publicImagesLoading || myImagesLoading;
 
+    useEffect(() => {
+        if (!imageOpenRequest || imageOpenRequest.markerId !== point.id) {
+            return;
+        }
+        const { imageId } = imageOpenRequest;
+        setRequestedImage(null);
+        setShouldOpenViewer(false);
+        let cancelled = false;
+        void getUGCImageById(point.id, imageId)
+            .then((image) => {
+                if (cancelled) return;
+                setRequestedImage(image);
+                setSelectedImageId(image.id);
+                setShouldOpenViewer(true);
+                clearImageOpenRequest();
+            })
+            .catch(() => {
+                if (cancelled) return;
+                clearImageOpenRequest();
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [clearImageOpenRequest, imageOpenRequest, point.id]);
+
+    const acknowledgeViewerOpen = useCallback(() => {
+        // This only acknowledges the one-time signal; it does not close the viewer.
+        setShouldOpenViewer(false);
+    }, []);
+
     const patchActiveImage = useCallback((patch: (image: UGCImage) => UGCImage) => {
         if (!active) return;
         setImages((current) => current.map((image) => (image.id === active.id ? patch(image) : image)));
         setMyImages((current) => current.map((image) => (image.id === active.id ? patch(image) as UGCSubmissionImage : image)));
+        setRequestedImage((current) => (current?.id === active.id ? patch(current) : current));
     }, [active]);
 
     const applyServerImage = useCallback((serverImage: UGCImageActionPatch) => {
@@ -188,6 +251,9 @@ const useUGCPointImages = (point: IMarkerData): PointImagesState => {
             ...serverImage,
             status: (serverImage as UGCSubmissionImage).status ?? image.status,
         } : image)));
+        setRequestedImage((current) => (current?.id === serverImage.id
+            ? { ...current, ...serverImage }
+            : current));
     }, []);
 
     return {
@@ -209,6 +275,8 @@ const useUGCPointImages = (point: IMarkerData): PointImagesState => {
         target,
         patchActiveImage,
         applyServerImage,
+        shouldOpenViewer,
+        acknowledgeViewerOpen,
     };
 };
 

--- a/talos/src/store/marker.ts
+++ b/talos/src/store/marker.ts
@@ -14,9 +14,18 @@ import {
     WORLD_TYPE_COUNT_MAP,
 } from '@/data/marker';
 
+export type ImageOpenRequest = {
+    markerId: string;
+    imageId: string;
+    generation: number;
+};
+
 interface IMarkerStore {
     currentActivePoint: IMarkerData | null;
     setCurrentActivePoint: (point: IMarkerData) => void;
+    imageOpenRequest: ImageOpenRequest | null;
+    openMarkerImage: (markerId: string, imageId: string) => void;
+    clearImageOpenRequest: () => void;
     filter: string[];
     points: string[];
     switchFilter: (typeKey: string) => void;
@@ -44,14 +53,31 @@ export const useMarkerStore = create<IMarkerStore>()(
     persist(
         (set, get) => ({
             currentActivePoint: null,
+            imageOpenRequest: null,
             setCurrentActivePoint: (point) => {
                 const prev = get().currentActivePoint;
                 // If user clicks the same point again, still emit an update so UI can re-open.
                 if (prev?.id === point.id) {
-                    set({ currentActivePoint: { ...point } });
+                    set({ currentActivePoint: { ...point }, imageOpenRequest: null });
                     return;
                 }
-                set({ currentActivePoint: point });
+                set({ currentActivePoint: point, imageOpenRequest: null });
+            },
+            openMarkerImage: (markerId, imageId) => {
+                const nextImageId = imageId.trim();
+                if (!nextImageId) return;
+                set((state) => ({
+                    imageOpenRequest: {
+                        markerId: String(markerId),
+                        imageId: nextImageId,
+                        generation: (state.imageOpenRequest?.generation ?? 0) + 1,
+                    },
+                }));
+            },
+            clearImageOpenRequest: () => {
+                if (get().imageOpenRequest) {
+                    set({ imageOpenRequest: null });
+                }
             },
             filter: [],
             points: [],

--- a/talos/src/utils/navigation.ts
+++ b/talos/src/utils/navigation.ts
@@ -5,7 +5,14 @@ import { useMarkerStore } from '@/store/marker';
 import { findMarkerById } from '@/data/marker';
 import { REGION_DICT } from '@/data/map';
 
-export interface SharedPointTarget {
+// A marker link focuses one content item. Add a comment variant when supported.
+export type MarkerContentTarget = { kind: 'image'; id: string };
+
+export interface MarkerNavigationOptions {
+    content?: MarkerContentTarget;
+}
+
+export interface SharedPointTarget extends MarkerNavigationOptions {
     regionKey: string;
     subregionKey?: string;
     pointId: string;
@@ -43,6 +50,7 @@ const normalizeTarget = (target: SharedPointTarget): SharedPointTarget => ({
     regionKey: target.regionKey,
     subregionKey: target.subregionKey,
     pointId: String(target.pointId),
+    content: target.content,
 });
 
 const navigateToPoint = async (target: SharedPointTarget): Promise<void> => {
@@ -83,6 +91,9 @@ const navigateToPoint = async (target: SharedPointTarget): Promise<void> => {
 
     // Ensure detail panel has the focused target.
     useMarkerStore.getState().setCurrentActivePoint(markerData);
+    if (target.content?.kind === 'image') {
+        useMarkerStore.getState().openMarkerImage(markerData.id, target.content.id);
+    }
 
     const targetZoom = Math.min(TARGET_ZOOM, mapCore.map.getMaxZoom());
     const [lat, lng] = markerData.pos;
@@ -133,7 +144,7 @@ export const navigateToSharedPoint = (target: SharedPointTarget): void => {
     void flushPendingNavigation();
 };
 
-export const navigateToMarkerId = async (pointId: string): Promise<boolean> => {
+export const navigateToMarkerId = async (pointId: string, options: MarkerNavigationOptions = {}): Promise<boolean> => {
     const point = await findMarkerById(String(pointId));
     if (!point) return false;
 
@@ -146,6 +157,7 @@ export const navigateToMarkerId = async (pointId: string): Promise<boolean> => {
         regionKey,
         subregionKey: point.subregId,
         pointId: point.id,
+        content: options.content,
     });
     return true;
 };

--- a/talos/src/utils/shareLink.ts
+++ b/talos/src/utils/shareLink.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { IMarkerData } from '@/data/marker';
 import { generatePointShareUrl } from '@/utils/urlState';
+import type { MarkerNavigationOptions } from '@/utils/navigation';
 
 const COPY_POPUP_DURATION_MS = 1500;
 
@@ -17,13 +18,19 @@ export const copyTextToClipboard = async (text: string): Promise<boolean> => {
     }
 };
 
-export const usePointShareLink = (point: Pick<IMarkerData, 'id' | 'type' | 'subregId'> | null | undefined) => {
+export const usePointShareLink = (
+    point: Pick<IMarkerData, 'id' | 'type' | 'subregId'> | null | undefined,
+    options: MarkerNavigationOptions = {},
+) => {
     const [copiedPopupVisible, setCopiedPopupVisible] = useState(false);
     const copyPopupTimerRef = useRef<number | null>(null);
 
     const pointShareUrl = useMemo(
-        () => (point ? generatePointShareUrl(point) : ''),
-        [point],
+        () => {
+            if (!point) return '';
+            return generatePointShareUrl(point, { content: options.content });
+        },
+        [options.content, point],
     );
 
     useEffect(() => {

--- a/talos/src/utils/ugcClient.ts
+++ b/talos/src/utils/ugcClient.ts
@@ -345,6 +345,29 @@ export async function listUGCMyImages(markerId: string): Promise<UGCSubmissionIm
     return listUGCMyImagesByMarkerIds([markerId]).then((grouped) => grouped[markerId] ?? []);
 }
 
+export async function getUGCImageById(markerId: string, imageId: string): Promise<UGCImage> {
+    const scope = import.meta.env.DEV ? 'test' : 'prod';
+    const search = new URLSearchParams({
+        markerId,
+        scope,
+    });
+    const response = await fetch(
+        `${UGC_API_BASE}/images/${encodeURIComponent(imageId)}?${search.toString()}`,
+        {
+            credentials: 'include',
+            headers: getAuthHeaders(),
+        },
+    );
+    if (!response.ok) {
+        throw await readUGCError(response);
+    }
+    const payload = await response.json() as { item?: UGCImage };
+    if (!payload.item) {
+        throw new UGCClientError('Image response is missing.', 'UGC_ERROR');
+    }
+    return normalizeUGCImage(payload.item);
+}
+
 export async function listUGCMyImagesByMarkerIds(markerIds: string[]): Promise<Record<string, UGCSubmissionImage[]>> {
     const normalizedIds = [...new Set(markerIds.map((item) => item.trim()).filter(Boolean))];
     const result: Record<string, UGCSubmissionImage[]> = {};

--- a/talos/src/utils/urlState.ts
+++ b/talos/src/utils/urlState.ts
@@ -16,7 +16,7 @@ import {
 } from '@/data/marker';
 import { REGION_DICT } from '@/data/map';
 import { getLangFromUrlCode, getLangUrlCode } from '@/utils/lang';
-import { navigateToSharedPoint } from '@/utils/navigation';
+import { navigateToSharedPoint, type MarkerNavigationOptions, type SharedPointTarget } from '@/utils/navigation';
 import { completeCurrentUserGuide } from '@/store/userGuide';
 
 // URL 參數名稱
@@ -27,6 +27,7 @@ const PARAM_REGION = 'r';
 const PARAM_SUBREGION = 's';
 const PARAM_POINT = 'p';
 const PARAM_POINT_TOKEN = 'x';
+const PARAM_IMAGE = 'imageId';
 const MAP_URL_PARAMS = [
     PARAM_LANG,
     PARAM_FILTER,
@@ -543,13 +544,18 @@ export const generatePointShareShortUrl = (point: Pick<IMarkerData, 'id' | 'type
     return `?${tokenParams.toString()}`;
 };
 
-export const generatePointShareUrl = (point: Pick<IMarkerData, 'id' | 'type' | 'subregId'>): string => {
+export const generatePointShareUrl = (
+    point: Pick<IMarkerData, 'id' | 'type' | 'subregId'>,
+    options: MarkerNavigationOptions = {},
+): string => {
     const tokenOrFallback = buildPointShareToken(point);
     const pointShareOrigin = getPointShareOrigin();
-    if (tokenOrFallback.startsWith('?')) {
-        return `${pointShareOrigin}/${tokenOrFallback}`;
+    const path = tokenOrFallback.startsWith('?') ? tokenOrFallback : encodeURIComponent(tokenOrFallback);
+    const url = new URL(`${pointShareOrigin}/${path}`);
+    if (options.content?.kind === 'image') {
+        url.searchParams.set(PARAM_IMAGE, options.content.id);
     }
-    return `${pointShareOrigin}/${encodeURIComponent(tokenOrFallback)}`;
+    return url.toString();
 };
 
 /**
@@ -666,42 +672,52 @@ export const applyUrlParams = async (): Promise<void> => {
     const pointIdFromToken = pointTokenParam ? decodePointIdToken(pointTokenParam) : null;
     const resolvedFromToken = pointIdFromToken ? await resolvePointShareTarget(pointIdFromToken) : null;
     const resolvedFromType = typeParam ? await resolveArchiveTypeShareTarget(typeParam) : null;
+    const imageId = params.get(PARAM_IMAGE)?.trim() || undefined;
+
+    let destination: SharedPointTarget | undefined;
 
     if (resolvedFromToken) {
         mergeFilterKeys([resolvedFromToken.point.type]);
-        navigateToSharedPoint({
+        destination = {
             regionKey: resolvedFromToken.regionKey,
             subregionKey: resolvedFromToken.point.subregId,
             pointId: resolvedFromToken.point.id,
-        });
+        };
     } else if (pointParam) {
         const resolvedFromQueryPoint = await resolvePointShareTarget(pointParam);
         if (resolvedFromQueryPoint) {
             mergeFilterKeys([resolvedFromQueryPoint.point.type]);
-            navigateToSharedPoint({
+            destination = {
                 regionKey: resolvedFromQueryPoint.regionKey,
                 subregionKey: resolvedFromQueryPoint.point.subregId,
                 pointId: resolvedFromQueryPoint.point.id,
-            });
+            };
         } else if (filterParam) {
             // Legacy 後備：舊鏈接僅在提供 f 時才嘗試按 r/s 導航。
             const fallbackRegion = useRegion.getState().currentRegionKey;
-            navigateToSharedPoint({
+            destination = {
                 regionKey: navRegion || fallbackRegion,
                 subregionKey: subregionParam || undefined,
                 pointId: pointParam,
-            });
+            };
         }
     } else if (resolvedFromType) {
         mergeFilterKeys([resolvedFromType.point.type]);
-        navigateToSharedPoint({
+        destination = {
             regionKey: resolvedFromType.regionKey,
             subregionKey: resolvedFromType.point.subregId,
             pointId: resolvedFromType.point.id,
-        });
+        };
     } else if (typeParam) {
         // ?type 找不到唯一點位時，退化為明文 f
         mergeFilterKeys([typeParam]);
+    }
+
+    if (destination) {
+        navigateToSharedPoint({
+            ...destination,
+            content: imageId ? { kind: 'image', id: imageId } : undefined,
+        });
     }
 
     // 清除地圖分享參數；僅保留認證流程必要參數，避免影響 reset password 流程。
@@ -714,6 +730,7 @@ export const applyUrlParams = async (): Promise<void> => {
         newParams.delete(PARAM_SUBREGION);
         newParams.delete(PARAM_POINT);
         newParams.delete(PARAM_POINT_TOKEN);
+        newParams.delete(PARAM_IMAGE);
 
         const preservedParams = new URLSearchParams();
         newParams.forEach((value, key) => {


### PR DESCRIPTION
## Problem

Shared links and notifications need to open a specific marker image, including images outside the six initially loaded.

## Changes

- Update marker navigation to carry an image target.
- Add `imageId` URL parsing and sharing.
- Fetch, select, and open the requested image.
- Navigate image notifications to their referenced image.

Requires [[backend PR #7](https://github.com/Terra-Online/Bayes/pull/7)].

## Flow

```mermaid
flowchart TD
    A["Shared image URL"] --> C["Open the marker"]
    B["Image notification"] --> C
    C --> D["Load the normal six-image list"]
    C --> E["Fetch requested image by image and marker IDs"]
    E --> F{"Lookup succeeds?"}
    F -- Yes --> G["Store requested image"]
    D --> H["Merge carousel images by ID"]
    G --> H
    G --> I["Select requested image and open viewer"]
    F -- No --> J["Remain on marker without auto-opening"]
```

## Verification
- Frontend TypeScript checking passed.
- ESLint passed for changed production files.